### PR TITLE
fix: challenges - concurrency - get random duration with mutex to avoid race condition

### DIFF
--- a/09-challenges/concurrency/begin/main.go
+++ b/09-challenges/concurrency/begin/main.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -13,9 +14,17 @@ import (
 )
 
 var random *rand.Rand
+var randomMutex sync.Mutex
 
 func init() {
 	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func getRandomDurationInSeconds(n int) time.Duration {
+	defer randomMutex.Unlock()
+
+	randomMutex.Lock()
+	return time.Duration(random.Intn(n)) * time.Second
 }
 
 type counter interface {
@@ -32,7 +41,7 @@ func (l letterCounter) name() string {
 func (l letterCounter) count(input string) int {
 	result := 0
 	fmt.Println(l.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if unicode.IsLetter(char) {
 			result++
@@ -50,7 +59,7 @@ func (n numberCounter) name() string {
 func (n numberCounter) count(input string) int {
 	result := 0
 	fmt.Println(n.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if unicode.IsNumber(char) {
 			result++
@@ -68,7 +77,7 @@ func (s symbolCounter) name() string {
 func (s symbolCounter) count(input string) int {
 	result := 0
 	fmt.Println(s.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if !unicode.IsLetter(char) && !unicode.IsNumber(char) {
 			result++

--- a/09-challenges/concurrency/end/main.go
+++ b/09-challenges/concurrency/end/main.go
@@ -13,9 +13,17 @@ import (
 )
 
 var random *rand.Rand
+var randomMutex sync.Mutex
 
 func init() {
 	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func getRandomDurationInSeconds(n int) time.Duration {
+	defer randomMutex.Unlock()
+
+	randomMutex.Lock()
+	return time.Duration(random.Intn(n)) * time.Second
 }
 
 type counter interface {
@@ -32,7 +40,7 @@ func (l letterCounter) name() string {
 func (l letterCounter) count(input string) int {
 	result := 0
 	fmt.Println(l.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if unicode.IsLetter(char) {
 			result++
@@ -50,7 +58,7 @@ func (n numberCounter) name() string {
 func (n numberCounter) count(input string) int {
 	result := 0
 	fmt.Println(n.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if unicode.IsNumber(char) {
 			result++
@@ -68,7 +76,7 @@ func (s symbolCounter) name() string {
 func (s symbolCounter) count(input string) int {
 	result := 0
 	fmt.Println(s.name(), "working...")
-	time.Sleep(time.Duration(random.Intn(5)) * time.Second)
+	time.Sleep(getRandomDurationInSeconds(5))
 	for _, char := range input {
 		if !unicode.IsLetter(char) && !unicode.IsNumber(char) {
 			result++

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
-github.com/aws/aws-sdk-go v1.51.2 h1:Ruwgz5aqIXin5Yfcgc+PCzoqW5tEGb9aDL/JWDsre7k=
-github.com/aws/aws-sdk-go v1.51.2/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,16 +18,10 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
-golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
when running the concurrency challenge code
calling `random.Intn` is showing racing errors
![image](https://github.com/user-attachments/assets/19a6a08f-9f66-4a2c-a5a9-221a59717357)

after fix:
![image](https://github.com/user-attachments/assets/07d48f0f-7ed8-4f32-b187-f599a8e3c651)
